### PR TITLE
Different GCC 4.5.2 and GCC 4.6.0 behaviour

### DIFF
--- a/namecoin.cpp
+++ b/namecoin.cpp
@@ -1617,7 +1617,7 @@ bool CNamecoinHooks::GenesisBlock(CBlock& block)
     if (fTestNet)
         return false;
 
-    ::GenesisBlock(block, NAME_COIN_GENESIS_EXTRA);
+    return ::GenesisBlock(block, NAME_COIN_GENESIS_EXTRA);
 }
 
 int CNamecoinHooks::LockinHeight()


### PR DESCRIPTION
Adding missing return solved this issue for me when compiling with GCC 4.6.0:

$ ./namecoind 
namecoind: main.cpp:2002: bool LoadBlockIndex(bool): Assertion `block.hashMerkleRoot == uint256("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b")' failed.
Aborted
