### PR TITLE
Fix for jgarzik's getblockbycount patch.. resubmitted, should apply cleanly

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -326,6 +326,11 @@ inline std::string ValueString(const std::vector<unsigned char>& vch)
         return HexStr(vch);
 }
 
+inline std::string PureString(const std::vector<unsigned char>& vch)
+{
+    return HexStr(vch);
+}
+
 inline std::string StackString(const std::vector<std::vector<unsigned char> >& vStack)
 {
     std::string str;
@@ -688,7 +693,7 @@ public:
                 return str;
             }
             if (0 <= opcode && opcode <= OP_PUSHDATA4)
-                str += ValueString(vch);
+                str += PureString(vch);
             else
                 str += GetOpName(opcode);
         }


### PR DESCRIPTION
jgarzik's getblockbycount patch fails in namecoin because it utilizes
ValueString(), which in bitcoin assumes that any value <= 4 bytes long must
be a number (and interprets it as such.) This is fine in bitcoin: I
can't imagine a scenario where a script value is smaller than 5 bytes and
isn't a number. Here, though, we have domains that are smaller than that.

This fixes that issue and makes the hex values in the output of the
scriptPubKey for the updates/etc correctly interpretable again.
