### PR TITLE
Add block chain lockins for namecoin.

### DIFF
--- a/src/namecoin.cpp
+++ b/src/namecoin.cpp
@@ -1690,6 +1690,17 @@ int CNamecoinHooks::LockinHeight()
 
 bool CNamecoinHooks::Lockin(int nHeight, uint256 hash)
 {
+    if (!fTestNet)
+        if ((nHeight == 2016 && hash != uint256("0x0000000000660bad0d9fbde55ba7ee14ddf766ed5f527e3fbca523ac11460b92")) ||
+                (nHeight ==   4032 && hash != uint256("0x0000000000493b5696ad482deb79da835fe2385304b841beef1938655ddbc411")) ||
+                (nHeight ==   6048 && hash != uint256("0x000000000027939a2e1d8bb63f36c47da858e56d570f143e67e85068943470c9")) ||
+                (nHeight ==   8064 && hash != uint256("0x000000000003a01f708da7396e54d081701ea406ed163e519589717d8b7c95a5")) ||
+                (nHeight ==  10080 && hash != uint256("0x00000000000fed3899f818b2228b4f01b9a0a7eeee907abd172852df71c64b06")) ||
+                (nHeight ==  12096 && hash != uint256("0x0000000000006c06988ff361f124314f9f4bb45b6997d90a7ee4cedf434c670f")) ||
+                (nHeight ==  14112 && hash != uint256("0x00000000000045d95e0588c47c17d593c7b5cb4fb1e56213d1b3843c1773df2b")) ||
+                (nHeight ==  16128 && hash != uint256("0x000000000001d9964f9483f9096cf9d6c6c2886ed1e5dec95ad2aeec3ce72fa9")) ||
+                (nHeight ==  18940 && hash != uint256("0x00000000000087f7fc0c8085217503ba86f796fa4984f7e5a08b6c4c12906c05")))
+            return false;
     return true;
 }
 


### PR DESCRIPTION
Hi,

Given that someone's threatening to rewrite a whole bunch of Namecoin block chain history with a 51% attack, I thought it might be a good idea to add some block chain lockins. The attached (but untested since I don't have the resources to attempt such an attack myself) change hopefully does this. It includes lockins at every difficulty adjustment to protect against theoretical attacks that could otherwise allow someone to get around the lockins.
