### PR TITLE
Add name_history RPC command and allow only real namecoin addresses

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -181,7 +181,7 @@ inline bool AddressToHash160(const char* psz, uint160& hash160Ret)
     if (vch.size() != sizeof(hash160Ret) + 1)
         return false;
     memcpy(&hash160Ret, &vch[1], sizeof(hash160Ret));
-    return (nVersion <= GetAddressVersion());
+    return (nVersion == GetAddressVersion());
 }
 
 inline bool AddressToHash160(const std::string& str, uint160& hash160Ret)


### PR DESCRIPTION
Address starting with '1' will be refused and hidden from wallet. Funds associated with '1' addresses are still usable because they are associated with a hash160 (and not directly an address), which does not depend from the address format. For each '1' address, a corresponding 'N/M' address exists if you want to find your funds in the block explorer. Don't forget to regularly make a backup of your wallet.
